### PR TITLE
Fixed default NotebookParams

### DIFF
--- a/Modules/DatabricksPS/Public/JobsAPI.ps1
+++ b/Modules/DatabricksPS/Public/JobsAPI.ps1
@@ -356,7 +356,7 @@ Function Start-DatabricksJob
 	(
 		[Parameter(Mandatory = $true, Position = 1, ValueFromPipelineByPropertyName = $true)] [Alias("job_id")] [int64] $JobID, 
 		[Parameter(Mandatory = $false, Position = 2)] [string[]] $JarParams = @(), 
-		[Parameter(Mandatory = $false, Position = 3)] [hashtable] $NotebookParams = @(), 
+		[Parameter(Mandatory = $false, Position = 3)] [hashtable] $NotebookParams = @{}, 
 		[Parameter(Mandatory = $false, Position = 4)] [string[]] $PythonParams = @(), 
 		[Parameter(Mandatory = $false, Position = 5)] [string[]] $SparkSubmitParams = @()
 	)


### PR DESCRIPTION
Hello,

in Start-DatabricksJob, the parameter NotebookParams is of type hashtable but the default value is a list.

Best regards,
Steffen