### PR TITLE
Write rest method invocation details to debug stream

### DIFF
--- a/Modules/DatabricksPS/Public/General.ps1
+++ b/Modules/DatabricksPS/Public/General.ps1
@@ -55,7 +55,7 @@
 	-Headers @$(($headers | ConvertTo-Json -Depth 20).Replace('":', '" =').Replace('",', '";')) ``
 	-Body '$(($Body | Out-String).Trim('"').Replace('\r', '').Replace('\n', ''))' ``
 	-Verbose"
-	Write-Verbose "Executing the following nativ PowerShell command: `n# -----------------------------------------------`n$psCmd"
+	Write-Debug "Executing the following nativ PowerShell command: `n# -----------------------------------------------`n$psCmd"
 
 	if($script:dbApiCallRetryCount -gt 0)
 	{	


### PR DESCRIPTION
Request headers may contain sensitive values that would preferably only be visible in a debug context.