### PR TITLE
Fix token to securestring

### DIFF
--- a/Modules/DatabricksPS/Public/General.ps1
+++ b/Modules/DatabricksPS/Public/General.ps1
@@ -425,7 +425,11 @@ Function Set-DatabricksEnvironment {
 				$script:dbApiRootUrl = "https://$($azResource.Properties.workspaceUrl.Trim('/'))/api"
 
 				$azToken = Get-AzAccessToken -ResourceUrl "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d"
-				$script:dbAuthenticationHeader["Authorization"] = "$($azToken.Type) $($azToken.Token)"
+				$plainToken = $azToken.Token
+				if ($plainToken -is [System.Security.SecureString]) {
+					$plainToken = [System.Net.NetworkCredential]::new('', $plainToken).Password
+				}
+				$script:dbAuthenticationHeader["Authorization"] = "$($azToken.Type) $($plainToken)"
 			}
 			else {
 				Write-Verbose "Using Username/Password authentication flow ..."

--- a/Modules/DatabricksPS/Public/General.ps1
+++ b/Modules/DatabricksPS/Public/General.ps1
@@ -427,7 +427,7 @@ Function Set-DatabricksEnvironment {
 				$azToken = Get-AzAccessToken -ResourceUrl "2ff814a6-3304-4ab8-85cb-cd0e6f879c1d"
 				$plainToken = $azToken.Token
 				if ($plainToken -is [System.Security.SecureString]) {
-					$plainToken = [System.Net.NetworkCredential]::new('', $plainToken).Password
+					$plainToken = ConvertFrom-SecureString -AsPlainText -SecureString $plainToken
 				}
 				$script:dbAuthenticationHeader["Authorization"] = "$($azToken.Type) $($plainToken)"
 			}


### PR DESCRIPTION
With `Az.Accounts` v5.1.0, the token is retrieved as secure string. This PR addresses the convertion to plain token for bearer authorization header.